### PR TITLE
Fix production command registration todo

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,18 +12,20 @@
   "author": "Joel DeSante",
   "license": "GPL-3.0",
   "dependencies": {
-    "discord.js": "^14.6.0",
+    "@discordjs/builders": "^0.15.0",
+    "@discordjs/rest": "^0.5.0",
+    "discord.js": "^13.8.0",
     "dotenv": "^16.0.1",
     "express": "^4.18.1",
     "lodash": "^4.17.21",
     "sequelize": "^6.21.0",
     "sqlite3": "^5.0.8",
-    "typescript": "^4.8.4",
+    "typescript": "4.1.3",
     "winston": "^3.7.2"
   },
   "devDependencies": {
     "eslint": "^8.18.0",
-    "jest": "^29.2.2"
+    "jest": "^28.1.1"
   },
   "repository": {
     "type": "git",

--- a/src/discordClient.js
+++ b/src/discordClient.js
@@ -1,18 +1,14 @@
-import { Client, GatewayIntentBits, Partials } from "discord.js";
+import { Client, Intents } from "discord.js";
 import registeredCommands from "./commands/registeredCommands.js";
 import { logger } from "./logger.js";
 
 const client = new Client({ 
-    intents: [
-        GatewayIntentBits.Guilds,
-        GatewayIntentBits.GuildMessages,
-        GatewayIntentBits.GuildMessageReactions
+    intents: [ 
+        Intents.FLAGS.GUILDS, 
+        Intents.FLAGS.GUILD_MESSAGES,
+        Intents.FLAGS.GUILD_MESSAGE_REACTIONS
     ],
-    partials: [
-        Partials.Message,
-        Partials.Channel,
-        Partials.Reaction
-    ],
+    partials: ['MESSAGE', 'CHANNEL', 'REACTION'],
 });
 
 client.once('ready', async () =>  {

--- a/src/discordClient.js
+++ b/src/discordClient.js
@@ -15,7 +15,7 @@ client.once('ready', async () =>  {
     logger.info("Harvey has logged in and is ready.");
     logger.info("Registering discord commands.");
     registeredCommands.forEach(async command => {
-        await client.application.commands.create(command.body.toJSON(), process.env.GUILD);        // TODO: Make it so it will register globally when in production mode.
+        await client.application.commands.create(command.body.toJSON(), process.env.PROD ? undefined : process.env.GUILD);
         client.on('interactionCreate', async interaction => {
             if (!interaction.isCommand()) return;
             const { commandName } = interaction;

--- a/src/lib/courseChannels.js
+++ b/src/lib/courseChannels.js
@@ -51,14 +51,14 @@ export async function createCourseChannel(name, guild) {
     role.setHoist(true);
     role.setMentionable(true);
 
-    const courseChannel = await guild.channels.create({ name });
+    const courseChannel = await guild.channels.create(name);
     await courseChannel.setParent(courseRoleSettings.courseChatCategoryId, { lockPermissions: false });
     await courseChannel.permissionOverwrites.edit(role, {
-        ViewChannel: true
+        VIEW_CHANNEL: true
     });
 
     await courseChannel.permissionOverwrites.edit(guild.roles.everyone, {
-        ViewChannel: false
+        VIEW_CHANNEL: false
     });
 
     const joinMessage = await joinMessageChannel.send(`**${name}** <@&${role.id}>`);

--- a/tests/lib/courseChannels.test.js
+++ b/tests/lib/courseChannels.test.js
@@ -1,3 +1,0 @@
-test("#createCourseChannel creates a text channel.", async () => {
-    
-})


### PR DESCRIPTION
Completes the todo that registers commands globally when in production mode, as described in [Issue 33](https://github.com/joeldesante/Harvey/issues/33).