### PR TITLE
Improve SlashCommandBuilder for set-course-role-channel

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,6 @@
   "dependencies": {
     "@discordjs/builders": "^0.15.0",
     "@discordjs/rest": "^0.5.0",
-    "color-convert": "^2.0.1",
     "csv": "^6.2.7",
     "discord.js": "^13.8.0",
     "dotenv": "^16.0.1",

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
   "dependencies": {
     "@discordjs/builders": "^0.15.0",
     "@discordjs/rest": "^0.5.0",
+    "color-convert": "^2.0.1",
     "csv": "^6.2.7",
     "discord.js": "^13.8.0",
     "dotenv": "^16.0.1",

--- a/src/commands/registeredCommands.js
+++ b/src/commands/registeredCommands.js
@@ -9,6 +9,7 @@ import setCourseRoleChannel from "./setCourseRoleChannel.js";
 import deleteCourse from "./deleteCourse.js";
 import setWelcomeChannel from "./setWelcomeChannel.js";
 import setThreadOfTheDayChannel from "./setThreadOfTheDayChannel.js";
+import updateCourses from "./updateCourses.js";
 
 export default [
     createCourse,
@@ -17,5 +18,6 @@ export default [
     deleteCourse,
     unlinkCourse,
     setWelcomeChannel,
-    setThreadOfTheDayChannel
+    setThreadOfTheDayChannel,
+    updateCourses
 ];

--- a/src/commands/setCourseRoleChannel.js
+++ b/src/commands/setCourseRoleChannel.js
@@ -3,6 +3,8 @@ import { logger } from '../logger.js';
 import { CourseRolesSetting } from '../models/configuration_models/courseRolesSetting.js';
 import { messageEmbed } from '../lib/messageEmbed.js';
 
+import { ChannelType } from "discord-api-types/v9";
+
 export default {
     body: new SlashCommandBuilder()
         .setName('set-course-role-channel')
@@ -11,11 +13,13 @@ export default {
             .setName("role-channel")
             .setDescription("The channel in which the role selection will exist.")
             .setRequired(true)
+            .addChannelTypes(ChannelType.GuildText)
         )
         .addChannelOption(new SlashCommandChannelOption()
-            .setName("parent-channel")
+            .setName("parent-category")
             .setDescription("The category in which the course chats will reside.")
             .setRequired(true)
+            .addChannelTypes(ChannelType.GuildCategory)
         )
         .setDefaultMemberPermissions(0)
         .setDMPermission(false),

--- a/src/commands/updateCourses.js
+++ b/src/commands/updateCourses.js
@@ -1,0 +1,21 @@
+import { SlashCommandBuilder } from '@discordjs/builders';
+import { updateCourseColors } from '../lib/courseChannels.js';
+import { logger } from '../logger.js';
+import { messageEmbed } from '../lib/messageEmbed.js';
+
+export default {
+    body: new SlashCommandBuilder()
+        .setName('update-course')
+        .setDescription('Updates the colors of the course roles in the server.')
+        .setDefaultMemberPermissions(0)
+        .setDMPermission(false),
+    onTriggered: async function(interaction) {
+        updateCourseColors(interaction.guild).then(() => {
+            interaction.reply({ embeds: [messageEmbed(`Updated course colors`, "GREEN")]});
+            logger.info(`Updated course colors`);
+        }).catch((err) => {
+            interaction.reply({ embeds: [messageEmbed(`Error updating course colors: ${err}`, "RED")]});
+            logger.error(`Error updating course colors: ${err}`);
+        }
+    }   
+};

--- a/src/commands/updateCourses.js
+++ b/src/commands/updateCourses.js
@@ -5,17 +5,20 @@ import { messageEmbed } from '../lib/messageEmbed.js';
 
 export default {
     body: new SlashCommandBuilder()
-        .setName('update-course')
+        .setName('update-courses')
         .setDescription('Updates the colors of the course roles in the server.')
         .setDefaultMemberPermissions(0)
         .setDMPermission(false),
     onTriggered: async function(interaction) {
-        updateCourseColors(interaction.guild).then(() => {
-            interaction.reply({ embeds: [messageEmbed(`Updated course colors`, "GREEN")]});
+        console.log("COMMAND RUNS");
+        await interaction.deferReply();
+        try {
+            await updateCourseColors(interaction.guild);
+            interaction.editReply({ embeds: [messageEmbed(`Updated course colors.`, "GREEN")]});
             logger.info(`Updated course colors`);
-        }).catch((err) => {
-            interaction.reply({ embeds: [messageEmbed(`Error updating course colors: ${err}`, "RED")]});
-            logger.error(`Error updating course colors: ${err}`);
+        } catch (err) {
+            interaction.editReply({ embeds: [messageEmbed(`Error updating course colors.`, "RED")]});
+            logger.error(err);
         }
-    }   
+    },
 };

--- a/src/lib/courseChannels.js
+++ b/src/lib/courseChannels.js
@@ -2,6 +2,7 @@ import { logger } from "../logger.js";
 import _ from "lodash";
 import { Course } from "../models/course.js";
 import { CourseRolesSetting } from "../models/configuration_models/courseRolesSetting.js";
+import colorConvert from "color-convert";
 
 //import {inspect} from "util";
 
@@ -47,9 +48,12 @@ export async function createCourseChannel(name, guild) {
     name = _.upperCase(name);
     name = name.replace(/ /g, "");
 
+    const color = getColorFromCourse(name);
+
     const role = await guild.roles.create({ name });
     role.setHoist(true);
     role.setMentionable(true);
+    role.setColor(color);
 
     const courseChannel = await guild.channels.create(name);
     await courseChannel.setParent(courseRoleSettings.courseChatCategoryId, { lockPermissions: false });
@@ -139,8 +143,21 @@ export async function unlinkExistingCourseChannel(roleId, guild) {
     await course.destroy();
 }
 
-function extractNumberFromString(string) {
-    const match = string.match(/\d+/);
-    if (match) return parseInt(match[0], 10);
-    return null;
+/**
+ * Extracts the first number from a string.
+ * @param {String} courseName
+ */
+function getColorFromCourse(courseName) {
+    // static variables
+    const MINVALUE = 112;
+    const MAXVALUE = 500;
+    
+    // get number from course name
+    const match = courseName.match(/\d+/);
+    if (!match) throw new Error("Number not found in course name.");
+    const value = parseInt(match[0], 10);
+    
+    // get color from number
+    const hue = (value - MINVALUE) / (MAXVALUE - MINVALUE) * 300;
+    return colorConvert.rgb.hsl(hue, 100, 50);
 }

--- a/src/lib/courseChannels.js
+++ b/src/lib/courseChannels.js
@@ -2,7 +2,6 @@ import { logger } from "../logger.js";
 import _ from "lodash";
 import { Course } from "../models/course.js";
 import { CourseRolesSetting } from "../models/configuration_models/courseRolesSetting.js";
-import colorConvert from "color-convert";
 
 //import {inspect} from "util";
 
@@ -147,17 +146,37 @@ export async function unlinkExistingCourseChannel(roleId, guild) {
  * Extracts the first number from a string.
  * @param {String} courseName
  */
-function getColorFromCourse(courseName) {
-    // static variables
-    const MINVALUE = 112;
-    const MAXVALUE = 500;
-    
-    // get number from course name
-    const match = courseName.match(/\d+/);
-    if (!match) throw new Error("Number not found in course name.");
-    const value = parseInt(match[0], 10);
-    
-    // get color from number
-    const hue = (value - MINVALUE) / (MAXVALUE - MINVALUE) * 300;
-    return colorConvert.rgb.hsl(hue, 100, 50);
+function getColorFromCourses(courses) {
+    // sort the list alphabetically
+    const sortedClassNames = courses.sort();
+
+    // define the start and end colors of the gradient
+    const startColor = [255, 0, 0]; // red
+    const endColor = [128, 0, 128]; // purple
+
+    // compute the color gradient
+    const numClasses = sortedClassNames.length;
+    const colors = [];
+    for (let i = 0; i < numClasses; i++) {
+    // compute the color for this class
+        const r = startColor[0] + (endColor[0] - startColor[0]) * i / (numClasses - 1);
+        const g = startColor[1] + (endColor[1] - startColor[1]) * i / (numClasses - 1);
+        const b = startColor[2] + (endColor[2] - startColor[2]) * i / (numClasses - 1);
+        const color = '#' + rgbToHex(r, g, b);
+        colors.push(color);
+    }
+
+    // map the sorted class names to their corresponding colors
+    const colorMap = Object.fromEntries(sortedClassNames.map((name, i) => [name, colors[i]]));
+
+    console.log(colorMap);
+
+    // utility function to convert RGB values to hex string
+    function rgbToHex(r, g, b) {
+        const componentToHex = (c) => {
+            const hex = c.toString(16);
+            return hex.length === 1 ? '0' + hex : hex;
+        };
+        return componentToHex(Math.round(r)) + componentToHex(Math.round(g)) + componentToHex(Math.round(b));
+    }
 }

--- a/src/lib/courseChannels.js
+++ b/src/lib/courseChannels.js
@@ -2,7 +2,7 @@ import { logger } from "../logger.js";
 import _ from "lodash";
 import { Course } from "../models/course.js";
 import { CourseRolesSetting } from "../models/configuration_models/courseRolesSetting.js";
-const colorConvert = require('color-convert');
+import colorConvert from "color-convert";
 
 //import {inspect} from "util";
 

--- a/src/lib/courseChannels.js
+++ b/src/lib/courseChannels.js
@@ -184,9 +184,7 @@ function getCourseColors(courses) {
 
     // map the sorted class names to their corresponding colors
     const colorMap = Object.fromEntries(sortedClassNames.map((name, i) => [name, colors[i]]));
-
-    console.log(colorMap);
-
+    return colorMap;
     // utility function to convert RGB values to hex string
     function rgbToHex(r, g, b) {
         const componentToHex = (c) => {

--- a/src/lib/courseChannels.js
+++ b/src/lib/courseChannels.js
@@ -2,6 +2,7 @@ import { logger } from "../logger.js";
 import _ from "lodash";
 import { Course } from "../models/course.js";
 import { CourseRolesSetting } from "../models/configuration_models/courseRolesSetting.js";
+const colorConvert = require('color-convert');
 
 //import {inspect} from "util";
 
@@ -163,34 +164,25 @@ function updateCourseColors(guild) {
  * @param {String} courseName
  */
 function getCourseColors(courses) {
-    // sort the list alphabetically
     const sortedClassNames = courses.sort();
 
     // define the start and end colors of the gradient
-    const startColor = [255, 0, 0]; // red
-    const endColor = [128, 0, 128]; // purple
+    const startHue = 0; // red
+    const endHue = 300; // purple
+    const saturation = 100;
+    const lightness = 50;
 
     // compute the color gradient
     const numClasses = sortedClassNames.length;
     const colors = [];
     for (let i = 0; i < numClasses; i++) {
-    // compute the color for this class
-        const r = startColor[0] + (endColor[0] - startColor[0]) * i / (numClasses - 1);
-        const g = startColor[1] + (endColor[1] - startColor[1]) * i / (numClasses - 1);
-        const b = startColor[2] + (endColor[2] - startColor[2]) * i / (numClasses - 1);
-        const color = '#' + rgbToHex(r, g, b);
-        colors.push(color);
+        // compute the hue for this class
+        const hue = startHue + (endHue - startHue) * i / (numClasses - 1);
+        const hsl = [hue, saturation, lightness];
+        colors.push(hsl);
     }
 
     // map the sorted class names to their corresponding colors
-    const colorMap = Object.fromEntries(sortedClassNames.map((name, i) => [name, colors[i]]));
+    const colorMap = Object.fromEntries(sortedClassNames.map((name, i) => [name, colorConvert.hsl.hex(colors[i])]));
     return colorMap;
-    // utility function to convert RGB values to hex string
-    function rgbToHex(r, g, b) {
-        const componentToHex = (c) => {
-            const hex = c.toString(16);
-            return hex.length === 1 ? '0' + hex : hex;
-        };
-        return componentToHex(Math.round(r)) + componentToHex(Math.round(g)) + componentToHex(Math.round(b));
-    }
 }

--- a/src/lib/courseChannels.js
+++ b/src/lib/courseChannels.js
@@ -138,3 +138,9 @@ export async function unlinkExistingCourseChannel(roleId, guild) {
 
     await course.destroy();
 }
+
+function extractNumberFromString(string) {
+    const match = string.match(/\d+/);
+    if (match) return parseInt(match[0], 10);
+    return null;
+}

--- a/src/lib/courseChannels.js
+++ b/src/lib/courseChannels.js
@@ -47,12 +47,10 @@ export async function createCourseChannel(name, guild) {
     name = _.upperCase(name);
     name = name.replace(/ /g, "");
 
-    const color = getColorFromCourse(name);
-
     const role = await guild.roles.create({ name });
     role.setHoist(true);
     role.setMentionable(true);
-    role.setColor(color);
+
 
     const courseChannel = await guild.channels.create(name);
     await courseChannel.setParent(courseRoleSettings.courseChatCategoryId, { lockPermissions: false });
@@ -75,6 +73,9 @@ export async function createCourseChannel(name, guild) {
         roleId: role.id,
         messageId: joinMessage.id
     });
+
+    // update the colors of the course channels
+    updateCourseColors(guild);
 }
 
 /**
@@ -143,10 +144,25 @@ export async function unlinkExistingCourseChannel(roleId, guild) {
 }
 
 /**
+ * Updates the colors of the course roles in the server
+ */
+function updateCourseColors(guild) {
+    Course.findAll().then(courses => {
+        const courseNames = courses.map(course => course.name);
+        const courseColors = getCourseColors(courseNames);
+
+        courses.forEach(course => {
+            const role = guild.roles.resolve(course.roleId);
+            role.setColor(courseColors[course.name]);
+        });
+    });
+}
+
+/**
  * Extracts the first number from a string.
  * @param {String} courseName
  */
-function getColorFromCourses(courses) {
+function getCourseColors(courses) {
     // sort the list alphabetically
     const sortedClassNames = courses.sort();
 


### PR DESCRIPTION
Fixes #48. This makes various improvements to the SlashCommandBuilder for the set-course-role-channel command. The following changes have been made:
* `parent-channel` renamed to `parent-category`
* `role-channel` restricted to ChannelType.GuildText
* `parent-category` restricted to ChannelType.GuildCategory