### PR TITLE
Update CONTRIBUTING.md to reflect `dev` as primary branch

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,11 +1,23 @@
 # Welcome to the Harvey contribution guidelines
+
 Thank you for investing your time into Harvey!
 
+### Development Guidelines
+
+- Make sure that you branch from the `dev` branch. All new work is merged to the
+  `dev` branch.
+
 ### Pull Requests
-Once you are ready to merge your changes into our repository you can create a pull request.
+
+Once you are ready to merge your changes into our repository you can create a
+pull request.
 
 Here are a few things to keep in mind:
+
 - Don't forget to link PR to issue if you are solving one.
-- Please request for a code review from a project maintainer to expedite your merge.
+- Please request for a code review from a project maintainer to expedite your
+  merge.
 - Make sure you are fully satisfied with the work you are pushing
-- If you are introducing a new dependancy please ensure that it is well maintained and activly worked on. We may reject pull requests that rely on smaller, less widely known, deps.
+- If you are introducing a new dependancy please ensure that it is well
+  maintained and activly worked on. We may reject pull requests that rely on
+  smaller, less widely known, deps.


### PR DESCRIPTION
This adds the guidance to branch from and PR against `dev`.