### PR TITLE
Add support for REST API and Harvey Networks

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "discord-api-types": "^0.37.38",
     "discord.js": "^13.8.0",
     "dotenv": "^16.0.1",
-    "express": "^4.18.1",
+    "express": "^4.18.2",
     "lodash": "^4.17.21",
     "sequelize": "^6.21.0",
     "sqlite3": "^5.0.8",

--- a/src/api/network.ts
+++ b/src/api/network.ts
@@ -1,0 +1,61 @@
+import express from 'express';
+
+let network = express.Router();
+
+/**
+ * Returns all the networks which a given user has authority over
+ */
+network.get('/', (req, res) => {
+    res.json("networks");
+})
+
+/**
+ * Creates a new network
+ */
+network.post('/', (req, res) => {
+    res.json("networks");
+})
+
+/**
+ * Returns a network given an identifier
+ */
+network.get('/:id', (req, res) => {
+    res.json("networks");
+})
+
+/**
+ * Deletes a network given an identifier
+ */
+network.delete('/:id', (req, res) => {
+    res.json("networks");
+})
+
+/**
+ * Updates a network given the identifier
+ */
+network.put('/:id', (req, res) => {
+    res.json("networks");
+})
+
+/**
+ * Gets the currently register guilds for this network
+ */
+network.get('/:id/guilds', (req, res) => {
+    res.json("networks");
+})
+
+/**
+ * Registers a guild to this network given identifiers
+ */
+network.post('/:id/guilds', (req, res) => {
+    res.json("networks");
+})
+
+/**
+ * Removes a guild from a given network given identifiers
+ */
+network.delete('/:id/guilds/:id', (req, res) => {
+    res.json("networks");
+})
+
+export default network;

--- a/src/commands/network/createNetwork.ts
+++ b/src/commands/network/createNetwork.ts
@@ -1,0 +1,27 @@
+import { SlashCommandBuilder, SlashCommandStringOption } from '@discordjs/builders';
+import { createNetwork } from '../../lib/network';
+import { logger } from '../../logger';
+import { messageEmbed } from '../../lib/messageEmbed';
+import type { CommandInteraction } from 'discord.js';
+
+export default {
+    body: new SlashCommandBuilder()
+        .setName('create-network')
+        .setDescription('Creates a course chat for a given course.')
+        .addStringOption(new SlashCommandStringOption()
+            .setName("name")
+            .setDescription("The name of the network you'd like to create.")
+            .setRequired(true)
+        )
+        .setDefaultMemberPermissions(0)
+        .setDMPermission(false),
+    onTriggered: async function(interaction: CommandInteraction) {
+        const networkName = interaction.options.getString("name");
+        if (!networkName) {
+            throw new Error("Unable to obtain network name.");
+        }
+        await createNetwork(networkName);
+        interaction.reply({ embeds: [messageEmbed(`Created network ${networkName}`, "GREEN")]});
+        logger.info(`Created network ${networkName}`);
+    }   
+};

--- a/src/commands/network/joinNetwork.ts
+++ b/src/commands/network/joinNetwork.ts
@@ -1,0 +1,33 @@
+import { SlashCommandBuilder, SlashCommandStringOption } from '@discordjs/builders';
+import { joinNetwork } from '../../lib/network';
+import { logger } from '../../logger';
+import { messageEmbed } from '../../lib/messageEmbed';
+import type { CommandInteraction } from 'discord.js';
+
+export default {
+    body: new SlashCommandBuilder()
+        .setName('join-network')
+        .setDescription('Joins this server into a network of servers')
+        .addStringOption(new SlashCommandStringOption()
+            .setName("name")
+            .setDescription("The exact name of the network you'd like to join.")
+            .setRequired(true)
+        )
+        .setDefaultMemberPermissions(0)
+        .setDMPermission(false),
+    onTriggered: async function(interaction: CommandInteraction) {
+        logger.info("dasd")
+        const networkName = interaction.options.getString("name");
+        if (!networkName) {
+            throw new Error("Unable to obtain network name.");
+        }
+
+        const guildId = interaction.guildId;
+        console.log("A")
+        await joinNetwork(networkName, guildId);
+        console.log("B")
+
+        interaction.reply({ embeds: [messageEmbed(`Joined network ${networkName}`, "GREEN")]});
+        logger.info(`Joined network ${networkName}`);
+    }   
+};

--- a/src/commands/registerGuild.ts
+++ b/src/commands/registerGuild.ts
@@ -1,0 +1,16 @@
+import { SlashCommandBuilder } from '@discordjs/builders';
+import { logger } from '../logger';
+import { messageEmbed } from '../lib/messageEmbed';
+import type { CommandInteraction } from 'discord.js';
+
+export default {
+    body: new SlashCommandBuilder()
+        .setName('register')
+        .setDescription('Registers this guild with the Harvey registry.')
+        .setDefaultMemberPermissions(0)
+        .setDMPermission(false),
+    onTriggered: async function(interaction: CommandInteraction) {
+        interaction.reply({ embeds: [messageEmbed(`This guild is now registered with Harvey!`, "GREEN")]});
+        logger.info(`Registered Guild.`);
+    }   
+};

--- a/src/commands/registeredCommands.ts
+++ b/src/commands/registeredCommands.ts
@@ -10,6 +10,9 @@ import deleteCourse from "./deleteCourse";
 import setWelcomeChannel from "./setWelcomeChannel";
 import setThreadOfTheDayChannel from "./setThreadOfTheDayChannel";
 import updateCourses from "./updateCourses";
+import createNetwork from "./network/createNetwork"
+import joinNetwork from "./network/joinNetwork"
+import registerGuild from "./registerGuild";
 
 export default [
     createCourse,
@@ -20,4 +23,7 @@ export default [
     setWelcomeChannel,
     setThreadOfTheDayChannel,
     updateCourses,
+    createNetwork,
+    joinNetwork,
+    registerGuild
 ];

--- a/src/handlers/apiHandler.ts
+++ b/src/handlers/apiHandler.ts
@@ -1,0 +1,19 @@
+import express from "express";
+import network from "../api/network";
+import { logger } from "../logger";
+const PORT = 9090;
+
+export function registerAPIHandler() {
+    const api = express();
+    api.use(express.json())
+
+    api.use('/networks', network);
+
+    api.get('/', (req, res) => {
+        res.json('Harvey is alive.')
+    });
+
+    api.listen(PORT, () => {
+        logger.info(`Harvey API is running on port ${PORT}`);
+    });
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,6 +6,7 @@ import client from './discordClient';
 import { registerCourseChannelHandler } from './handlers/courseChannelHandler';
 import { registerWelcomeHandler } from './handlers/welcomeMessageHandler';
 import { registerHeartbeatHandler } from './handlers/heartbeatHandler';
+import { registerAPIHandler } from './handlers/apiHandler';
 
 logger.info(`Current working directory: ${process.cwd()}`);
 logger.info("Syncing with the database.");
@@ -17,6 +18,7 @@ logger.info("Registering handlers.");
 registerCourseChannelHandler(client);
 registerWelcomeHandler(client);
 registerHeartbeatHandler(client);
+registerAPIHandler();
 
 logger.info("Logging into Discord.");
 const TOKEN = process.env.DISCORD_TOKEN || "";

--- a/src/lib/network.ts
+++ b/src/lib/network.ts
@@ -1,0 +1,52 @@
+import { Network } from '../models/network';
+import { Guild } from '../models/guild';
+
+/**
+ * @param {string} name The name of the network.
+ */
+export async function createNetwork(name: string) {
+    await Network.create({
+        name: name
+    });    
+}
+
+/**
+ * @param {string} name The name of the network.
+ * @param {string} guildId The id of the guild.
+ */
+ export async function joinNetwork(name: string, guildId: string | null) {
+
+    console.log(1)
+    if(guildId === null) {
+        throw new Error("Invalid guild id.");
+    }
+    console.log(2)
+
+    const network = await Network.findOne({
+        where: {
+            name: name
+        }
+    });
+
+    console.log(3)
+
+    if(!network) {
+        throw new Error("Network not found");
+    }
+
+    console.log(4)
+    const guild = await Guild.findOne({
+        where: {
+            guildId: guildId
+        }
+    })
+
+    console.log(5)
+    if(!guild) {
+        throw new Error("Guild not found")
+    }
+
+    console.log(6)
+    network.addGuild(guild);
+    console.log(7)
+}

--- a/src/models/guild.ts
+++ b/src/models/guild.ts
@@ -1,0 +1,16 @@
+import { DataTypes, type InferAttributes, type InferCreationAttributes, Model, type Sequelize } from 'sequelize';
+
+class Guild extends Model<InferAttributes<Guild>, InferCreationAttributes<Guild>> {
+    declare guildId: string;
+}
+
+const GuildModelInit = (sequelize: Sequelize) => {
+    Guild.init({
+        guildId: DataTypes.STRING
+    }, {
+        sequelize,
+        modelName: 'Guild'
+    });
+};
+
+export { Guild, GuildModelInit };

--- a/src/models/index.ts
+++ b/src/models/index.ts
@@ -5,6 +5,9 @@ import { CourseModelInit } from './course';
 import { ThreadOfTheDayChannelSettingInit } from './configuration_models/threadOfTheDayChannelSetting';
 import { CourseRolesSettingModelInit } from './configuration_models/courseRolesSetting';
 import { WelcomeChannelModelInit } from './configuration_models/welcomeChannelSetting';
+import { NetworkModelInit } from './network';
+import { GuildModelInit } from './guild';
+import { UserModelInit } from './user';
 
 logger.info("Initializing database connection.");
 const sequelize = new Sequelize({
@@ -16,5 +19,8 @@ CourseModelInit(sequelize);
 CourseRolesSettingModelInit(sequelize);
 WelcomeChannelModelInit(sequelize);
 ThreadOfTheDayChannelSettingInit(sequelize);
+UserModelInit(sequelize);
+GuildModelInit(sequelize);
+NetworkModelInit(sequelize);
 
 export { sequelize };

--- a/src/models/network.ts
+++ b/src/models/network.ts
@@ -1,0 +1,33 @@
+import { 
+    DataTypes, 
+    Model,
+    type InferAttributes, 
+    type InferCreationAttributes, 
+    type Sequelize, 
+    type NonAttribute,
+    type HasManyAddAssociationMixin
+} from 'sequelize';
+import { Guild } from './guild';
+
+class Network extends Model<InferAttributes<Network>, InferCreationAttributes<Network>> {
+    declare name: string;
+    declare guilds?: NonAttribute<Guild[]>
+    declare addGuild: HasManyAddAssociationMixin<Guild, number>;
+}
+
+const NetworkModelInit = (sequelize: Sequelize) => {
+    Network.init({
+        name: {
+            type: DataTypes.STRING,
+            unique: true
+        }
+    }, {
+        sequelize,
+        modelName: 'Network'
+    });
+
+    Network.hasMany(Guild);
+    Guild.hasOne(Network);
+};
+
+export { Network, NetworkModelInit };

--- a/src/models/user.ts
+++ b/src/models/user.ts
@@ -1,0 +1,17 @@
+import { DataTypes, type InferAttributes, type InferCreationAttributes, Model, type Sequelize, type NonAttribute } from 'sequelize';
+import { Guild } from './guild';
+
+class User extends Model<InferAttributes<User>, InferCreationAttributes<User>> {
+    declare userId: string;
+}
+
+const UserModelInit = (sequelize: Sequelize) => {
+    User.init({
+        userId: DataTypes.STRING
+    }, {
+        sequelize,
+        modelName: 'User'
+    });
+};
+
+export { User, UserModelInit };


### PR DESCRIPTION
This update will include the first increment with regards to support for the backend API of Harvey along with support for server networks. 

Harvey server networks is a feature that allows for the linking of multiple related servers. In the case of Harvey, this is useful when announcements need to be made on all related servers at one time. Rather than the administrator of said servers copying/pasting the announcement multiple times across the network, the bot will propagate the announcement across the network automatically. 

Joining servers across a network also has the added benefit of opening a door to further cross-server interaction and integration for Harvey. For example, historically we have had issues with users who advertise services that violate the honor code, these users can be banned across the entire network with one command rather than having to ban them in every server they pop up in.